### PR TITLE
Add duplicate card

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,62 @@
         <button>Estadísticas</button>
       </div>
     </div>
+    <div class="card">
+      <div class="top-card">
+        <img src="./img/portada.png" alt="" class="issac-top" />
+      </div>
+      <div class="issac">
+        <span class="issac-nombre">ISSAC</span>
+        <img src="./img/issac.png" alt="" class="issac-imagen" />
+      </div>
+      <div class="descripcion">
+        <span
+          >Isaac es un niño que huye al sótano de su casa luego de que su madre,
+          convencida por una voz divina, intenta sacrificarlo en nombre de Dios.
+          En su descenso, enfrenta horrores grotescos, visiones de su trauma, y
+          versiones distorsionadas de sí mismo. The Binding of Isaac mezcla
+          acción y exploración con un profundo simbolismo religioso, culpa,
+          miedo y muerte. Cada muerte es un renacer... cada partida, una
+          pesadilla distinta.</span
+        >
+      </div>
+      <div class="card-footer">
+        <span class="estadistica-titulo">Estadística personaje</span>
+        <span class="des-estadistica">
+          💔 HP:
+          <span class="content-estadistica">
+            3 contenedores de corazones rojos</span
+          >
+        </span>
+        <span class="des-estadistica">
+          🗡️ Daño:
+          <span class="content-estadistica"> 3.5 por lágrima </span>
+        </span>
+        <span class="des-estadistica"
+          >💧 Lágrimas:
+          <span class="content-estadistica"
+            >dispara lágrimas como proyectiles</span
+          ></span
+        >
+        <span class="des-estadistica"
+          >🎲 Objeto inicial:
+          <span class="content-estadistica">The D6</span></span
+        >
+        <span class="des-estadistica"
+          >🧠 Estilo de juego:
+          <span class="content-estadistica">Balanceado</span></span
+        >
+        <span class="des-estadistica"
+          >🔓 Desbloqueo:
+          <span class="content-estadistica"
+            >Disponible desde el inicio</span
+          ></span
+        >
+      </div>
+      <div class="boton">
+        <button>Estadísticas</button>
+      </div>
+    </div>
   </body>
   <script src="main.js"></script>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,8 +1,7 @@
-let boton = document.querySelector('.boton')
-let cardFooter = document.querySelector('.card-footer')
-boton.addEventListener('click',activar)
-
-function activar() {
-    cardFooter.classList.toggle('activo');
-}
-console.log('xd')
+document.querySelectorAll('.boton button').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const card = btn.closest('.card');
+        const footer = card.querySelector('.card-footer');
+        footer.classList.toggle('activo');
+    });
+});

--- a/style.css
+++ b/style.css
@@ -3,10 +3,12 @@ body{
     padding: 0;
     box-sizing: border-box;
     background-color: rgb(119, 72, 72);
-    height: 100vh;
+    min-height: 100vh;
     display: flex;
     justify-content: center;
     align-items: center;
+    gap: 20px;
+    flex-wrap: wrap;
 }
 .card{
     width: 500px;


### PR DESCRIPTION
## Summary
- show two identical cards on the page
- update layout to handle multiple cards
- add JS logic to toggle stats for each card

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683f6cc1ef8083299a8e3a6f4514055e